### PR TITLE
fix(cmp): add vscode cmp menu icons, menu direction, fix snippet engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This is my custom Neovim configuration. I am currently using Neovim version 0.7
 and the configuration is written entirely in Lua.
 
+# Prerequisites
+- Install [this
+font](https://github.com/microsoft/vscode-codicons/raw/main/dist/codicon.ttf)
+to get completion menu icons properly rendering
+
 # Usage
 
 ```bash

--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -1,60 +1,120 @@
-local status_ok, cmp = pcall(require, "cmp")
-if not status_ok then
+local status_cmp_ok, cmp = pcall(require, "cmp")
+if not status_cmp_ok then
 	return
 end
 
-cmp.setup {
-  window = {
-    completion = cmp.config.window.bordered(),
-    documentation = cmp.config.window.bordered(),
-  },
-  mapping = cmp.mapping.preset.insert({
-    ['<Tab>'] = cmp.mapping.confirm({ select = true }),
-    ['<C-d>'] = cmp.mapping.scroll_docs(-4),
-    ['<C-f>'] = cmp.mapping.scroll_docs(4),
-    ['<C-Space>'] = cmp.mapping.complete(),
-    ['<C-e>'] = cmp.mapping.abort(),
-  }),
-  sources = cmp.config.sources({
-    { name = 'nvim_lsp' },
-  }, {
-    { name = 'buffer' },
-    { name = 'path' },
-  }),
-  formatting = {
-    format = function(entry, vim_item)
-      vim_item.menu = ({
-        luasnip = "[LuaSnip]",
-        nvim_lsp = "[LSP]",
-        buffer = "[Buffer]",
-        path = "[Path]",
-      })[entry.source.name]
-      return vim_item
-    end
-  }
+local status_luasnip_ok, luasnip = pcall(require, "luasnip")
+if not status_luasnip_ok then
+	return
+end
+
+local cmp_kinds = {
+	Text = "  ",
+	Method = "  ",
+	Function = "  ",
+	Constructor = "  ",
+	Field = "  ",
+	Variable = "  ",
+	Class = "  ",
+	Interface = "  ",
+	Module = "  ",
+	Property = "  ",
+	Unit = "  ",
+	Value = "  ",
+	Enum = "  ",
+	Keyword = "  ",
+	Snippet = "  ",
+	Color = "  ",
+	File = "  ",
+	Reference = "  ",
+	Folder = "  ",
+	EnumMember = "  ",
+	Constant = "  ",
+	Struct = "  ",
+	Event = "  ",
+	Operator = "  ",
+	TypeParameter = "  ",
 }
 
-cmp.setup.cmdline('/', {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = {
-    { name = 'buffer' }
-  }
-})
-cmp.setup.cmdline('?', {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = {
-    { name = 'buffer' }
-  }
+cmp.setup({
+	snippet = {
+		expand = function(args)
+			luasnip.lsp_expand(args.body)
+		end,
+	},
+	window = {
+		completion = cmp.config.window.bordered(),
+		documentation = cmp.config.window.bordered(),
+	},
+	view = {
+		entries = { name = "custom", selection_order = "near_cursor" },
+	},
+	mapping = cmp.mapping.preset.insert({
+		["<Tab>"] = cmp.mapping.confirm({ select = true }),
+		["<C-d>"] = cmp.mapping.scroll_docs(-4),
+		["<C-f>"] = cmp.mapping.scroll_docs(4),
+		["<C-Space>"] = cmp.mapping.complete(),
+		["<C-e>"] = cmp.mapping.abort(),
+	}),
+	sources = cmp.config.sources({
+		{ name = "nvim_lsp" },
+	}, {
+		{ name = "buffer" },
+		{ name = "path" },
+	}),
+	formatting = {
+		format = function(entry, vim_item)
+			vim_item.menu = ({
+				luasnip = "[LuaSnip]",
+				nvim_lsp = "[LSP]",
+				buffer = "[Buffer]",
+				path = "[Path]",
+			})[entry.source.name]
+			vim_item.kind = (cmp_kinds[vim_item.kind] or "") .. vim_item.kind
+			return vim_item
+		end,
+	},
 })
 
-local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
-require('lspconfig')['tsserver'].setup {
-  capabilities = capabilities
-}
-require('lspconfig')['rust_analyzer'].setup {
-  capabilities = capabilities
-}
+cmp.setup.cmdline("/", {
+	mapping = cmp.mapping.preset.cmdline(),
+	sources = {
+		{ name = "buffer" },
+	},
+	view = {
+		entries = { name = "custom", selection_order = "near_cursor" },
+	},
+})
+
+cmp.setup.cmdline("?", {
+	mapping = cmp.mapping.preset.cmdline(),
+	sources = {
+		{ name = "buffer" },
+	},
+	view = {
+		entries = { name = "custom", selection_order = "near_cursor" },
+	},
+})
+
+cmp.setup.cmdline(":", {
+	mapping = cmp.mapping.preset.cmdline(),
+	sources = cmp.config.sources({
+		{ name = "path" },
+	}, {
+		{ name = "cmdline" },
+	}),
+	view = {
+		entries = { name = "custom", selection_order = "near_cursor" },
+	},
+})
+
+local capabilities = require("cmp_nvim_lsp").update_capabilities(vim.lsp.protocol.make_client_capabilities())
+require("lspconfig")["tsserver"].setup({
+	capabilities = capabilities,
+})
+require("lspconfig")["rust_analyzer"].setup({
+	capabilities = capabilities,
+})
 
 local cmp_autopairs = require("nvim-autopairs.completion.cmp")
-cmp.event:on( 'confirm_done', cmp_autopairs.on_confirm_done())
-
+cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -1,12 +1,5 @@
--- TODO: go through this setup and take plugins that look goodplu
+-- TODO: go through this setup and take plugins that look good
 -- https://github.com/kabinspace/AstroVim
-
--- TODO: implement the mapping popup I saw in Chris@Machine's video
--- TODO: separate out my nvim config from my dotfiles and make a new gh repo
--- TODO: sort out the /after directory into nicely imported code in /lua that works out the box
--- TODO: implement this when I have time
--- use 'dhruvmanila/telescope-bookmarks.nvim'  -- https://github.com/dhruvmanila/telescope-bookmarks.nvim
--- TODO: implement lsp installer and make sure lua is set up correctly
 
 local fn = vim.fn
 
@@ -72,8 +65,7 @@ return packer.startup(function(use)
 
 	-- Completion
 	use("hrsh7th/nvim-cmp") -- https://github.com/hrsh7th/nvim-cmp
-	-- TODO: reimplement this as the cmp uses it for certain LSP source suggestions
-	-- use 'L3MON4D3/LuaSnip' -- https://github.com/L3MON4D3/LuaSnip
+	use("L3MON4D3/LuaSnip") -- https://github.com/L3MON4D3/LuaSnip
 	use("hrsh7th/cmp-buffer")
 	use("hrsh7th/cmp-nvim-lsp") -- https://github.com/hrsh7th/cmp-nvim-lsp
 	use("hrsh7th/cmp-path")


### PR DESCRIPTION
vscode menu icons just make the completion menu look better. ive tried the other menu view types too
and prefer the vertical version, but now have the completion menu showing suggestions closest to
cursor based on if it opens above or below. snippet engine was simply just required to install the
snippet plugin and specify it in the config as i thought

fix #5