### PR TITLE
feat(snippets): more snippets including first vim regex for capitalising first letter

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -79,3 +79,6 @@ keymap("n", "<leader>9", "<cmd>BufferLineGoToBuffer 9<CR>", opts)
 
 -- Editor support
 keymap("n", "<leader>b", "<cmd>ToggleAlternate<CR>", opts)
+
+-- Reload Neovim
+keymap("n", "<leader>lc", "<cmd>luafile $MYVIMRC<CR>", opts)

--- a/snippets/typescript.snippets
+++ b/snippets/typescript.snippets
@@ -69,6 +69,8 @@ snippet imp "import { member } from 'xyz'"
 	
 snippet ima "import * from 'xyz'"
 	import * from '${1}';
+snippet expa "export * from 'xyz'"
+	export * from '${1}';
 snippet af "() =>"
 	(${1}) => ${0:${VISUAL}}
 snippet afb "() => {}"

--- a/snippets/typescriptreact.snippets
+++ b/snippets/typescriptreact.snippets
@@ -10,7 +10,6 @@ snippet ncf "Full component file"
 		);
 	};
 
-
 snippet nc "New component"
 	import { FC } from 'react';
 
@@ -21,6 +20,35 @@ snippet nc "New component"
 			${4}
 		);
 	};
+
+# Hooks
+snippet uses useState
+	const [${1:state}, set${1/.*/\u\0/g}] = useState(${2:initialState});
+
+snippet usee useEffect
+	useEffect(() => {
+		${1}
+	});
+
+snippet userd useReducer
+	const [${1:state}, ${2:dispatch}] = useReducer(${3:reducer});
+
+snippet userf useRef
+	const ${1:refContainer} = useRef(${2:initialValue});
+
+snippet usect useContext
+	const ${1:value} = useContext(${2:MyContext});
+
+snippet usecb useCallback
+	const ${1:memoizedCallback} = useCallback(
+	() => {
+		${2}(${3})
+	},
+	[$3]
+	);
+
+snippet usem useMemo
+	const ${1:memoizedCallback} = useMemo(() => ${2}(${3}), [$3]);
 
 # THE BELOW IS COPIED FROM THE TYPESCRIPT SNIPPETS, DO NOT CHANGE HERE AS IT
 # WILL BE OVERWRITTEN
@@ -94,6 +122,8 @@ snippet imp "import { member } from 'xyz'"
 	
 snippet ima "import * from 'xyz'"
 	import * from '${1}';
+snippet expa "export * from 'xyz'"
+	export * from '${1}';
 snippet af "() =>"
 	(${1}) => ${0:${VISUAL}}
 snippet afb "() => {}"


### PR DESCRIPTION
also adding reloading of nvim config without having to quit vim so that i can play with things more
easily. mappings don't seem to be updated but mostly everything else comes in. interestingly trying
regex within the snippy text transforms it actually takes vim regex patterns, see the manual for
more info on this as that was very helpful and not documented anywhere else that i searched

re #16